### PR TITLE
Allow interviewer to automatically copy prompt snippets (#9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,14 @@
 node_modules/
 
 .vscode/
+apiNotes.js 
 
+# Generated
 bundle.js
-
-config.js
-apiNotes.js
-
-staticTiHistory.js
-
 codestitchUrl.txt
+
+# config files
+config.js
+snippetsData.js
+staticTiHistory.js
 zoomSecret.js

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -5,6 +5,7 @@ import Credits from './Credits';
 import Notes from './Notes';
 import Prompt from './Prompt';
 import Setup from './Setup';
+import Snippets from './Snippets';
 import searchStaticTiHistory from './searchStaticTiHistory';
 import searchLiveTiHistory from './searchLiveTiHistory';
 import {
@@ -31,7 +32,7 @@ class App extends Component {
       zoom: ''
     },
     promptUrl: '',
-    promptSelected: false,
+    promptSelected: '',
     suggestedPrompt: '',
     staticTiRows: null,
     liveTiRows: null,
@@ -69,7 +70,7 @@ class App extends Component {
   }
 
   copyPrompt = async event => {
-    this.setState({ promptSelected: true, suggestedPrompt: '' });
+    this.setState({ promptSelected: event.target.id, suggestedPrompt: '' });
     const promptName = event.target.id;
     const promptId = prompts[promptName];
     const { candidateName, startTime } = this.state;
@@ -196,7 +197,7 @@ class App extends Component {
           zoom: ''
         },
         promptUrl: '',
-        promptSelected: false,
+        promptSelected: '',
         suggestedPrompt: '',
         staticTiRows: null,
         liveTiRows: null,
@@ -270,6 +271,9 @@ class App extends Component {
         <br />
         <Prompt
           {...{ loggedIn, copyPrompt, promptUrl, promptSelected }}
+        />
+        <Snippets 
+          {...{ promptSelected }}
         />
         <br />
         <Notes />

--- a/client/components/Prompt.jsx
+++ b/client/components/Prompt.jsx
@@ -2,9 +2,18 @@ import React, { Component } from 'react';
 
 class Prompt extends Component {
   state = {
-    show: true,
+    initialShow: false,
+    show: false,
     source: ''
   };
+
+  componentDidUpdate() {
+    if ((this.props.promptSelected || this.state.show) && !this.state.initialShow) {
+      // Expands on either prompt selection or title click,
+      // but obeys toggleShow afterwards
+      this.setState({ initialShow: true, show: true })
+    }
+  }
 
   setSource = source => {
     this.setState({ source });
@@ -15,7 +24,11 @@ class Prompt extends Component {
   };
 
   render() {
-    const { show, source } = this.state;
+    const { 
+      initialShow,
+      show,
+      source,
+    } = this.state;
     const {
       loggedIn,
       copyPrompt,
@@ -26,7 +39,7 @@ class Prompt extends Component {
     return (
       <div>
         <h4 onClick={this.toggleShow}> Prompt </h4>
-        {show ? 
+        {initialShow && show ? 
           <div>
             <input
               placeholder={"Google Drive prompt link"}

--- a/client/components/Snippets.jsx
+++ b/client/components/Snippets.jsx
@@ -1,0 +1,85 @@
+import React, { Component } from 'react';
+import Clipboard from 'clipboard';
+import snippetsData from '../../snippetsData';
+
+class Snippets extends Component {
+  state = {
+    initialShow: false,
+    show: false,
+    snippetIndex: 0,
+  };
+
+  componentDidUpdate() {
+    if ((this.props.promptSelected || this.state.show) && !this.state.initialShow) {
+      // Expands on either prompt selection or title click,
+      // but obeys toggleShow afterwards
+      this.setState({ initialShow: true, show: true })
+    }
+  }
+ 
+  componentDidMount() {
+    new Clipboard('.copy')
+  }
+
+  increment = () => this.setState({ 
+    snippetIndex: Math.min(
+      snippetsData[this.props.promptSelected].length - 1,
+      this.state.snippetIndex + 1
+    )
+  })
+  
+  decrement = () => this.setState({ 
+    snippetIndex: Math.max(this.state.snippetIndex - 1, 0)
+  })
+
+  toggleShow = () => {
+    this.setState({ show: !this.state.show });
+  };
+
+  render() {
+    const {
+      initialShow,
+      show,
+      snippetIndex,
+    } = this.state;
+    const promptSnippets = snippetsData[this.props.promptSelected];
+    const snippet = promptSnippets ? promptSnippets[snippetIndex] : '';
+    return (
+      <div>
+        <h4 onClick={this.toggleShow}> Prompt snippets </h4>
+        {initialShow && show ?
+          <div>
+            <textarea
+              id="snippetField"
+              value={snippet}
+              readOnly
+            />
+            <button
+              onClick={this.decrement}
+            >
+              Go back
+            </button>
+            <button
+              className="copy"
+              data-clipboard-target="#snippetField"
+            >
+              Copy
+            </button>
+            <button
+              className="copy"
+              onClick={this.increment}
+              data-clipboard-target="#snippetField"
+            >
+              Copy and go forward
+            </button>
+          </div> :
+          <span>
+            &nbsp;...
+          </span>
+        }
+      </div>
+    )
+  }
+}
+
+export default Snippets;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2125,6 +2125,16 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "clipboard": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.1.tgz",
+      "integrity": "sha512-7yhQBmtN+uYZmfRjjVjKa0dZdWuabzpSKGtyQZN+9C8xlC788SSJjOHWh7tzurfwTqTD5UDYAhIv5fRJg3sHjQ==",
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "cliui": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
@@ -2716,6 +2726,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "depd": {
       "version": "1.1.2",
@@ -4617,6 +4632,14 @@
         "ignore": "^3.3.5",
         "pify": "^3.0.0",
         "slash": "^1.0.0"
+      }
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "requires": {
+        "delegate": "^3.1.2"
       }
     },
     "google-auth-library": {
@@ -8278,6 +8301,11 @@
       "integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg=",
       "dev": true
     },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
+    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -9137,6 +9165,11 @@
       "requires": {
         "setimmediate": "^1.0.4"
       }
+    },
+    "tiny-emitter": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
+      "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "axios": "^0.18.0",
     "babel-polyfill": "^6.26.0",
     "body-parser": "^1.18.3",
+    "clipboard": "^2.0.1",
     "css-loader": "^1.0.0",
     "express": "^4.16.3",
     "googleapis": "^32.0.0",

--- a/snippetsData-example.js
+++ b/snippetsData-example.js
@@ -1,0 +1,20 @@
+const snippetsData = {
+  versionControl: [
+    `This will be the first snippet to appear when Version Control is selected.
+    When you click on "Copy and Go Forward", this selection will be copied to the clipboard...`, 
+    `...and this selection will be displayed.`, 
+    ``,
+  ],
+  MRP: [
+    ``, 
+    ``, 
+    ``
+  ],
+  bookLibrary: [
+    ``,
+    ``,
+    ``
+  ],
+};
+
+export default snippetsData;


### PR DESCRIPTION
* Implement first-draft snippets component

* Update gitignore for snippets data file

* Add basic hide/show logic to Snippets

* Minimize Prompt + Snippets until clicked or prompt selected

* Modify example snippets

* Refer to snippetsData consistently

* Do minor cleanup